### PR TITLE
Fix corner case issue with size

### DIFF
--- a/format/mp4/mp4io/mp4io.go
+++ b/format/mp4/mp4io/mp4io.go
@@ -386,8 +386,19 @@ func ReadFileAtoms(r io.ReadSeeker) (atoms []Atom, err error) {
 			}
 			return
 		}
-		size := pio.U32BE(taghdr[0:])
+		size := uint64(pio.U32BE(taghdr[0:]))
 		tag := Tag(pio.U32BE(taghdr[4:]))
+
+		if size == 1 {
+			if _, err = io.ReadFull(r, taghdr); err != nil {
+				if err == io.EOF {
+					err = nil
+				}
+				return
+			}
+
+			size = pio.U64BE(taghdr) - 8
+		}
 
 		var atom Atom
 		switch tag {


### PR DESCRIPTION
This PR fixes a corner case bug with the size field in a header. When the size is `1`, the true size is the 8 bytes following the header tag. 